### PR TITLE
Dockerコンテナ起動時にコンテナ名にアンダーバーが使えないように修正

### DIFF
--- a/src/main/java/com/yo1000/bluefairy/controller/rest/v1/ContainerRestController.java
+++ b/src/main/java/com/yo1000/bluefairy/controller/rest/v1/ContainerRestController.java
@@ -42,7 +42,7 @@ public class ContainerRestController {
     public ContainerCreated postCreate(@RequestBody ContainerCreate containerCreate,
                                        @RequestParam String name,
                                        @RequestHeader(value = "X-LOGIN-USER", required = false) String username) {
-        Assert.isTrue(name.isEmpty() || name.matches("^/?[a-zA-Z0-9_-]+$"), "Name format is invalid.");
+        Assert.isTrue(name.isEmpty() || name.matches("^/?[a-zA-Z0-9-]+$"), "Name format is invalid.");
 
         return this.getContainerService().runContainer(containerCreate, name, username);
     }

--- a/src/main/resources/templates/images.html
+++ b/src/main/resources/templates/images.html
@@ -1,7 +1,4 @@
-<!--
 <html xmlns:th="http://www.thymeleaf.org">
--->
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <head th:replace="_fragment :: header (title=${title} + ' - bluefairy')"></head>
 <body>
 <nav th:replace="_fragment :: navigator"></nav>

--- a/src/main/resources/templates/images.html
+++ b/src/main/resources/templates/images.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head th:replace="_fragment :: header (title=${title} + ' - bluefairy')"></head>
 <body>

--- a/src/main/resources/templates/images.html
+++ b/src/main/resources/templates/images.html
@@ -1,5 +1,7 @@
-<!doctype html>
+<!--
 <html xmlns:th="http://www.thymeleaf.org">
+-->
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
 <head th:replace="_fragment :: header (title=${title} + ' - bluefairy')"></head>
 <body>
 <nav th:replace="_fragment :: navigator"></nav>
@@ -35,7 +37,7 @@
                         <div class="form-group">
                             <label for="exposablePorts" class="col-sm-4 control-label">Name</label>
                             <div class="col-sm-6">
-                                <input type="text" name="name" placeholder="/?[a-zA-Z0-9_-]+"
+                                <input type="text" name="name" placeholder="/?[a-zA-Z0-9-]+"
                                        class="action-modal-name form-control input-sm"/>
                             </div>
                         </div>


### PR DESCRIPTION
bluefairyで作成したDockerコンテナに接続する際に、コンテナ名を使用したホスト名を作成し
接続しておりましたが、ホスト名にアンダーバーが含まれるとIEでCookieを送付できなくなるという現象が起きました

https://connect.microsoft.com/IE/feedback/details/905702/ie11-bug-cookies-fail-to-save-load-when-browsing-a-site-with-underscores-in-its-subdomain

Docker ではコンテナ名にアンダーバーが含まれていても問題はないのですが
コンテナ名を使用したドメイン名を使用する場合に問題が出てしまう為
コンテナ名にアンダーバーが使用できないよう修正したいと考えました。

マージのご検討をよろしくお願いいたします。
